### PR TITLE
🐛 Fix the install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,56 @@ This repo has 3 main parts:
 2) ```./ui``` The mcp ui. This is an extension to the OpenShift UI to give a mobile centric view and set of features.
 
 3) ```./docs``` This holds design docs, architectural docs, use cases and development guides etc.
+
+## Prerequisites
+
+* `oc` cli >= 3.6.0-rc0 https://github.com/openshift/origin/releases (Known issue with service-catalog in 3.6.0)
+* Node.js >= 4(for install script(s))
+
+## Local Installation
+
+Start openshift, configure it for MCP Extension development, and install the mobile apiserver
+
+```
+./ui/install.sh
+```
+
+The MCP Extension should now be visible in the OpenShift Web Console after the 'origin' container has restarted.
+Visit https://127.0.0.1:8443 to see the Console.
+
+To create a mobile app using `oc`:
+
+```
+oc create -f ./server/hack/install-apiserver/MobileApp.json
+```
+
+## Cleanup
+
+If you want to just stop the cluster:
+
+```
+oc cluster down
+```
+
+To stop the cluster and remove any openshift config (Destructive):
+
+```bash
+./ui/clean.sh
+```
+
+## Troubleshooting
+
+### error: unable to recognize "./server/hack/install-apiserver/MobileApp.json": no matches for mobile.k8s.io/, Kind=MobileApp
+
+If you get this error straight after installing locally, the mobile-apiserver may not be running yet.
+You can check that by doing:
+
+```
+oc get po -l 'app=apiserver' -n mobile
+
+NAME                         READY     STATUS    RESTARTS   AGE
+apiserver-1747434594-pzdvv   2/2       Running   0          13m
+```
+
+You can debug the reason why its not running by using `oc get events -n mobile` and looking for any errors or failure events.
+If the apiserver is not showing, it may have failed to install. Check the install logs for any errors.

--- a/server/hack/install-apiserver/openshift/install.sh
+++ b/server/hack/install-apiserver/openshift/install.sh
@@ -4,11 +4,16 @@
 #ROUTING_SUFFIX="${HOSTNAME}"
 #sudo ifconfig lo0 alias ${PUBLIC_IP}
 #oc cluster up --image=openshift/origin --version=v3.6.0-rc.0 --service-catalog=true --routing-suffix=${ROUTING_SUFFIX} --public-hostname=${HOSTNAME}  --host-config-dir=/Users/kelly/openshift-config/openshift.local.config
-oc cluster up --image=openshift/origin --version=v3.6.0-rc.0 --service-catalog=true --host-config-dir=/Users/kelly/openshift-config/openshift.local.config
+#oc cluster up --image=openshift/origin --version=v3.6.0-rc.0 --service-catalog=true --host-config-dir=/Users/kelly/openshift-config/openshift.local.config
+
+set -x
 
 targetNamespace=mobile
 apiserverConfigDir=/tmp/mobile-apiserver/config
-masterConfigDir=${HOME}/openshift-config/openshift.local.config/master
+scriptPath=$(dirname $0)
+scriptAbsolutePath=$(cd $scriptPath && pwd)
+openshiftConfigDir=$(cd $scriptAbsolutePath/../../../../ui && pwd)
+masterConfigDir=${openshiftConfigDir}/master
 mkdir -p ${apiserverConfigDir} || true
 #nodeManifestDir=/Users/kelly/openshift-config/openshift.local.config/node-localhost/static-pods
 
@@ -27,7 +32,7 @@ done
 saToken=$(oc -n ${targetNamespace} sa get-token apiserver)
 # TODO do this a LOT better
 # start with admin.kubeconfig
-cp ${masterConfigDir}/admin.kubeconfig ${apiserverConfigDir}/kubeconfig
+sudo cp ${masterConfigDir}/admin.kubeconfig ${apiserverConfigDir}/kubeconfig
 # remove all users
 oc --config=${apiserverConfigDir}/kubeconfig config unset users
 # set the service account token

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,24 +1,29 @@
 # Mobile Control Panel UI
 
+## Overview
 
-## Prerequisites
+The Mobile Control Panel (MCP) UI is built using:
+* AngularJS https://angularjs.org/
+* Patternfly http://www.patternfly.org/
 
-* `oc` cli >= 3.6.0-rc0 https://github.com/openshift/origin/releases (Known issue with service-catalog in 3.6.0)
-* Node.js >= 4(for install script(s))
+It is developed as a set of OpenShift UI Extensions.
+All Javascript is delivered as a single file (mcp.js).
+All CSS is delivered as a single file (mcp.css).
 
-## Local Installation
+The extension config looks something like this in the OpenShift master-config.yaml
 
-Start openshift, configure it for MCP Extension development, and install the mobile apiserver
-
+```yaml
+assetConfig:
+  extensionDevelopment: true
+  extensionProperties: null
+  extensionScripts:
+    - /var/lib/origin/openshift.local.config/master/servicecatalog-extension.js
+    - /var/lib/origin/openshift.local.config/public/mcp.js
+  extensionStylesheets:
+    - /var/lib/origin/openshift.local.config/public/mcp.css
+  extensions:
+    - name: mcp
+      sourceDirectory: /var/lib/origin/openshift.local.config/public
 ```
-./install.sh
-```
 
-The MCP Extension should now be visible in the OpenShift Web Console after the 'origin' container has restarted.
-Visit https://127.0.0.1:8443 to see the Console.
-
-To create a mobile app, use `oc` e.g.
-
-```
-oc create -f ../server/hack/install-apiserver/MobileApp.json
-```
+When doing local development against an `oc cluster`, the `ui` folder would be mounted into the docker `origin` container as the config dir. This allows the path `/var/lib/origin/openshift.local.config/public` to point to the `./ui/public` folder.

--- a/ui/clean.sh
+++ b/ui/clean.sh
@@ -6,5 +6,8 @@ set -x
 oc cluster down
 
 # Remove openshift config dir things
-sudo rm -rf ./master
-sudo rm -rf ./node-localhost
+SCRIPT_PATH=$(dirname $0)
+SCRIPT_ABSOLUTE_PATH=$(cd $SCRIPT_PATH && pwd)
+
+sudo rm -rf ${SCRIPT_ABSOLUTE_PATH}/master
+sudo rm -rf ${SCRIPT_ABSOLUTE_PATH}/node-localhost

--- a/ui/install.sh
+++ b/ui/install.sh
@@ -36,7 +36,7 @@ oc patch scc/restricted -p '{"allowHostDirVolumePlugin":true}'
 
 # Install the Mobile API Server
 cd $MOBILE_API_SERVER_DIR
-bash -x $MOBILE_API_SERVER_INSTALL_SCRIPT
+$MOBILE_API_SERVER_INSTALL_SCRIPT
 
 # TODO: Wait for successful start of the Mobile API Server
 

--- a/ui/public/mcp.js
+++ b/ui/public/mcp.js
@@ -1,6 +1,6 @@
 console.log('Mobile Control Panel Extension Loaded');
 
-window.OPENSHIFT_CONSTANTS.PROJECT_NAVIGATION.splice(1, 0, 
+window.OPENSHIFT_CONSTANTS.PROJECT_NAVIGATION.splice(1, 0, {
   label: "Mobile",
   iconClass: "fa fa-mobile",
   href: "/mobile",


### PR DESCRIPTION
* Fix mobile-apiserver setup script to work on both linux & mac
* Fix mobile-apiserver setup script to re-use existing oc cluster & config dir
* Fix an mcp syntax error
* Fix the ui/clean.sh script to use absolute path to config dirs
* Update the main README to include the local setup instructions