### PR TITLE
✨ FH-3825 Allow Mobile Apps to be created from the MCP UI

### DIFF
--- a/ui/public/create-mobileapp.html
+++ b/ui/public/create-mobileapp.html
@@ -1,0 +1,38 @@
+<default-header class="top-header"></default-header>
+<div class="wrap no-sidebar">
+  <div class="sidebar-left collapse navbar-collapse navbar-collapse-2">
+    <navbar-utility-mobile></navbar-utility-mobile>
+  </div>
+  <div class="middle surface-shaded">
+    <!-- Middle section -->
+    <div class="middle-section">
+      <div class="middle-container">
+        <div class="middle-content">
+          <div class="container surface-shaded">
+            <div class="row">
+              <div class="col-md-10 col-md-offset-1">
+                <div ng-if="!project" class="mar-top-md">Loading...</div>
+                <div ng-if="project">
+                  <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
+                  <alerts alerts="alerts"></alerts>
+                  <div class="mar-top-xl">
+                    <h1>Create Mobile App</h1>
+                    <div class="help-block">
+                      
+                    </div>
+                    <create-mobile-app
+                      namespace="projectName"
+                      alerts="alerts"
+                      on-create="navigateBack()"
+                      on-cancel="navigateBack()">
+                    </create-mobile-app>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div><!-- /middle-content -->
+      </div><!-- /middle-container -->
+    </div><!-- /middle-section -->
+  </div><!-- /middle -->
+</div><!-- /wrap -->

--- a/ui/public/directives/create-mobileapp.html
+++ b/ui/public/directives/create-mobileapp.html
@@ -1,0 +1,60 @@
+<ng-form name="mobileappForm" class="create-mobileapp-form">
+  <div for="mobileappClientType" ng-if="!type" class="form-group mar-top-lg">
+    <label>Mobile App Type</label>
+    <ui-select required ng-model="newMobileapp.clientType" search-enabled="false">
+      <ui-select-match>{{$select.selected.label | upperFirst}} Mobile App</ui-select-match>
+      <ui-select-choices repeat="clientType in clientTypes">
+        {{clientType.label}} Mobile App
+      </ui-select-choices>
+    </ui-select>
+  </div>
+
+  <div ng-if="newMobileapp.clientType">
+    <div class="form-group">
+      <label for="mobileappName" class="required">Mobile App Name</label>
+        <span ng-class="{'has-error': nameTaken || (mobileappForm.mobileappName.$invalid && mobileappForm.mobileappName.$touched)}">
+          <input class="form-control"
+            id="mobileappName"
+            name="mobileappName"
+            ng-model="newMobileapp.data.mobileappName"
+            type="text"
+            autocorrect="off"
+            autocapitalize="off"
+            spellcheck="false"
+            aria-describedby="mobileapp-name-help"
+            ng-change="nameChanged()"
+            required>
+        </span>
+        <div class="has-error" ng-show="nameTaken">
+          <span class="help-block">
+            This name is already in use. Please choose a different name.
+          </span>
+        </div>
+        <div class="has-error" ng-show="mobileappForm.mobileappName.$invalid">
+          <div ng-show="mobileappForm.mobileappName.$error.pattern && mobileappForm.mobileappName.$touched" class="help-block">
+            {{nameValidation.description}}
+          </div>
+          <div ng-show="mobileappForm.mobileappName.$error.required && mobileappForm.mobileappName.$touched" class="help-block">
+            Name is required.
+          </div>
+          <div ng-show="mobileappForm.mobileappName.$error.maxlength && mobileappForm.mobileappName.$touched" class="help-block">
+            Can't be longer than {{nameValidation.maxlength}} characters.
+          </div>
+        </div>
+        <div class="help-block" id="mobileapp-name-help">
+          Unique name of the new mobile app.
+        </div>
+    </div>
+
+
+  </div>
+  <div class="buttons gutter-top-bottom">
+    <button class="btn btn-lg btn-primary"
+            type="button"
+            ng-disabled="mobileappForm.$invalid || mobileappForm.$pristine || invalidConfigFormat"
+            ng-click="create()">Create</button>
+    <button class="btn btn-lg btn-default"
+            type="button"
+            ng-click="cancel()">Cancel</button>
+  </div>
+</ng-form>

--- a/ui/public/mcp.css
+++ b/ui/public/mcp.css
@@ -4,3 +4,7 @@
     font-size: 25px;
   }
 }
+
+.row.row-cards-pf {
+  margin-bottom:50px;
+}

--- a/ui/public/mobile.html
+++ b/ui/public/mobile.html
@@ -9,7 +9,10 @@
           <div class="collapse navbar-collapse navbar-collapse-1">
             <ul class="nav navbar-nav navbar-primary">
               <li class="active">
-                <a href="#">Mobile Apps</a>
+                <a href="#">Mobile Overview</a>
+              </li>
+              <li>
+                <a href="#">Apps</a>
               </li>
               <li>
                 <a href="#">Data Storage</a>
@@ -18,7 +21,7 @@
                 <a href="#">Push Notifications</a>
               </li>
               <li>
-                <a href="#">Remote Debugging</a>
+                <a href="#">Security</a>
               </li>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">
@@ -26,6 +29,9 @@
                   <b class="caret"></b>
                 </a>
                 <ul class="dropdown-menu">
+                  <li>
+                    <a href="#">Remote Debugging</a>
+                  </li>
                   <li>
                     <a href="#">Key-Value Storage</a>
                   </li>
@@ -48,13 +54,75 @@
           <alerts alerts="overview.state.alerts"></alerts>
         </div>
         <div class="container-fluid">
-          <div  class="row row-cards-pf">
+          <h2>
+            Mobile Apps
+            <span class="page-header-link">
+              <a ng-href="http://feedhenry.org/docs/" target="_blank" href="http://feedhenry.org/docs/">
+              Learn More <i class="fa fa-external-link" aria-hidden="true"></i>
+              </a>
+            </span>
+            <!-- TODO: how to make this work  ng-if="project && ('mobileapps' | canI : 'create')" -->
+            <div class="pull-right ng-scope">
+            <a ng-href="project/{{project.metadata.name}}/create-mobileapp" class="btn btn-default">Create Mobile App</a>
+            </div>
+          </h2>
+          <div class="row row-cards-pf">
             <div ng-repeat="mobileapp in mobileapps" class="col-xs-12 col-sm-6 col-md-3">
               <div class="card-pf card-pf-accented card-pf-aggregate-status">
                 <h2 class="card-pf-title">Name:{{mobileapp.metadata.name}}</h2>
                 <div class="card-pf-body">
                   <span class="fa ng-class:['fa-' + mobileapp.metadata.annotations['mobile.k8s.io/iconClass']]"></span>
                   <span class="">{{mobileapp.spec.clientType}}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="vertical-divider"></div>
+
+          <h2>
+            Mobile Services
+            <span class="page-header-link">
+              <a ng-href="http://feedhenry.org/docs/" target="_blank" href="http://feedhenry.org/docs/">
+              Learn More <i class="fa fa-external-link" aria-hidden="true"></i>
+              </a>
+            </span>
+            <div class="pull-right ng-scope" ng-if="project && ('services' | canI : 'create')">
+            <a ng-href="project/{{project.metadata.name}}/create-mobileservice" class="btn btn-default">Create Mobile Service</a>
+            </div>
+          </h2>
+          <!-- TODO: limit this to 'mobile'' services -->
+          <div class="row row-cards-pf">
+            <div ng-repeat="mobileservice in mobileservices" class="col-xs-12 col-sm-6 col-md-3">
+              <div class="card-pf card-pf-accented card-pf-aggregate-status">
+                <h2 class="card-pf-title">Name:{{mobileservice.metadata.name}}</h2>
+                <div class="card-pf-body">
+                  <span class="fa ng-class:['fa-' + mobileservice.metadata.annotations['mobile.k8s.io/iconClass']]"></span>
+                  <span class="">{{mobileservice.spec.clientType}}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+
+          <h2>
+            Other Services
+            <span class="page-header-link">
+              <a ng-href="http://feedhenry.org/docs/" target="_blank" href="http://feedhenry.org/docs/">
+              Learn More <i class="fa fa-external-link" aria-hidden="true"></i>
+              </a>
+            </span>
+            <div class="pull-right ng-scope" ng-if="project && ('services' | canI : 'create')">
+            <a ng-href="project/{{project.metadata.name}}/create-otherservice" class="btn btn-default">Create Service</a>
+            </div>
+          </h2>
+          <!-- TODO: limit this to 'non-mobile'' services -->
+          <div class="row row-cards-pf">
+            <div ng-repeat="nonmobileservice in nonmobileservices" class="col-xs-12 col-sm-6 col-md-3">
+              <div class="card-pf card-pf-accented card-pf-aggregate-status">
+                <h2 class="card-pf-title">Name:{{nonmobileservice.metadata.name}}</h2>
+                <div class="card-pf-body">
+                  <span class="fa ng-class:['fa-' + nonmobileservice.metadata.annotations['mobile.k8s.io/iconClass']]"></span>
+                  <span class="">{{nonmobileservice.spec.clientType}}</span>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
* Update the Mobile left nav to open a Mobile Overview to show Apps & Services
* Add 'Apps' & 'Security' as top nav placeholders
* Add 'Create Mobile App' button to Mobile Overview page beside the Mobile Apps listing
* Hook up the button to a new view for creating a Mobile App
  * The new view allows the App Type and App Name to be specified
  * The new view is made up of:
    * create-mobileapp.html view and controller
    * create-mobileapp.html directive

![image](https://user-images.githubusercontent.com/878251/28968969-a20b49ac-78f0-11e7-9e37-6ae72919ba37.png)

![image](https://user-images.githubusercontent.com/878251/28968976-a604e3b0-78f0-11e7-91fb-7942d1be5ce6.png)
