### PR TITLE
FH-3829 Initial Ansible installer for MCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 server/.generate_exes
 server/config/
-server/bin/client-gen 
-server/bin/conversion-gen 
-server/bin/deepcopy-gen 
-server/bin/defaulter-gen 
-server/bin/informer-gen 
+server/bin/client-gen
+server/bin/conversion-gen
+server/bin/deepcopy-gen
+server/bin/defaulter-gen
+server/bin/informer-gen
 server/bin/lister-gen server/bin/server
 server/bin
+
+.vscode

--- a/installer/.gitignore
+++ b/installer/.gitignore
@@ -1,0 +1,3 @@
+*.retry
+andrewrothstein*
+openshift-origin-client-tools/

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,0 +1,40 @@
+# Mobile Control Panel (MCP) Ansible installer
+
+A collection of Ansible roles to install the Mobile Control Panel in OpenShift.
+This project will perform a number of tasks, namely:
+
+* Install the oc tool on the machine
+* Invoke `oc cluster up` with the Service Catalog enabled
+* Adding templates to the Template Service Broker in OpenShift
+* Installing the MCP UI and server components/resources
+* Creating an Ansible Service Broker in OpenShift
+
+## Prerequisites
+
+* A DockerHub account, credentials are required to set up the Ansible Service
+Broker.
+* Execute `ansible-galaxy install -r requirements.yml` in the current directory to
+install dependencies.
+* User with sudo permissions on machine.
+
+## Example
+
+**Running the installer against localhost:**
+`ansible-playbook playbook.yml -e "dockerhub_username=myuser" -e "dockerhub_password=mypass" --ask-become-pass`
+
+Once Ansible finished run `oc cluster status` to get the URL of the web console.
+
+## Variables
+
+Variables can be provided as arguments to the `ansible-playbook` command using
+`-e variable_name=variable_value` or by populating the
+`vars/mobile-control-panel.yml` file.
+
+### Mandatory
+* `dockerhub_username` - DockerHub username
+* `dockerhub_password` - DockerHub password
+
+***Note: If `dockerhub_username` and `dockerhub_password` are not specified the
+Ansible Service broker will not be created.***
+
+TODO: finish optional variables

--- a/installer/inventory
+++ b/installer/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/installer/playbook.yml
+++ b/installer/playbook.yml
@@ -1,0 +1,21 @@
+---
+
+- name: Setup OpenShift cluster with Mobile Control Panel and Service Brokers
+  hosts: localhost
+  roles:
+  - role: openshift-origin-client-tools
+    tags: install-oc
+
+  - role: oc-cluster-up
+    tags: oc-cluster-up
+
+  - role: template-service-broker-setup
+    tags: setup-tsb
+
+  - role: mobile-control-panel-setup
+    tags: setup-mcp
+
+  - role: ansible-service-broker-setup
+    tags: setup-asb
+  vars_files:
+  - "vars/mobile-control-panel.yml"

--- a/installer/requirements.yml
+++ b/installer/requirements.yml
@@ -1,0 +1,2 @@
+- src: andrewrothstein.openshift-origin-client-tools
+  name: openshift-origin-client-tools

--- a/installer/roles/ansible-service-broker-setup/defaults/main.yml
+++ b/installer/roles/ansible-service-broker-setup/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for ansible-service-broker-setup

--- a/installer/roles/ansible-service-broker-setup/files/provision-ansible-service-broker.sh
+++ b/installer/roles/ansible-service-broker-setup/files/provision-ansible-service-broker.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+readonly DOCKERHUB_USER="${0}"
+readonly DOCKERHUB_PASS="${1}"
+readonly DOCKERHUB_ORG="ansibleplaybookbundle"
+
+curl -s https://raw.githubusercontent.com/openshift/ansible-service-broker/master/templates/deploy-ansible-service-broker.template.yaml > /tmp/deploy-ansible-service-broker.template.yaml
+
+oc login -u system:admin
+oc new-project ansible-service-broker
+oc process -f /tmp/deploy-ansible-service-broker.template.yaml \
+    -n ansible-service-broker \
+    -p DOCKERHUB_USER="${DOCKERHUB_USER}" \
+    -p DOCKERHUB_PASS="${DOCKERHUB_PASS}" \
+    -p DOCKERHUB_ORG="${DOCKERHUB_ORG}" | oc create -f -
+
+if [ "${?}" -ne 0 ]; then
+	echo "Error processing template and creating deployment"
+	exit
+fi
+
+ASB_ROUTE=`oc get routes | grep ansible-service-broker | awk '{print $2}'`
+
+cat <<EOF > /tmp/ansible-service-broker.broker
+    apiVersion: servicecatalog.k8s.io/v1alpha1
+    kind: Broker
+    metadata:
+      name: ansible-service-broker
+    spec:
+      url: https://${ASB_ROUTE}
+      authInfo:
+        basicAuthSecret:
+          namespace: ansible-service-broker
+          name: asb-auth-secret
+EOF
+
+oc create -f /tmp/ansible-service-broker.broker

--- a/installer/roles/ansible-service-broker-setup/meta/main.yml
+++ b/installer/roles/ansible-service-broker-setup/meta/main.yml
@@ -1,0 +1,31 @@
+galaxy_info:
+  author: FeedHenry
+  description: Setup Ansible Service Broker in OpenShift
+
+  issue_tracker_url: https://github.com/feedhenry/mobile-control-panel/issues
+
+  license: license (MIT)
+
+  min_ansible_version: 2.2
+
+  platforms:
+  - name: macOS
+    versions:
+    - all
+  - name: OSX
+    versions:
+    - all
+  - name: Fedora
+    versions:
+    - 26
+    - 25
+
+  galaxy_tags:
+  - feedhenry
+  - openshift
+  - ansible
+  - service
+  - broker
+  - asb
+
+dependencies: []

--- a/installer/roles/ansible-service-broker-setup/tasks/main.yml
+++ b/installer/roles/ansible-service-broker-setup/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+# tasks file for ansible-service-broker-setup
+
+- name: Check if Ansible Service Broker already exists
+  shell: oc get broker ansible-service-broker
+  register: oc_get_broker
+  changed_when: false
+  failed_when:
+  - oc_get_broker.rc != 0
+  - oc_get_broker.stderr.find('NotFound') == -1
+
+- block:
+  - name: Ensure Ansible Service Broker install script is on host
+    copy:
+      src: ../files/provision-ansible-service-broker.sh
+      dest: /tmp/
+
+  - name: Make Ansible Service Broker install script executable
+    file:
+      dest: /tmp/provision-ansible-service-broker.sh
+      mode: u+x
+
+  - name: Execute Ansible Service Broker provision script
+    shell: bash /tmp/provision-ansible-service-broker.sh "{{ dockerhub_username }}" "{{ dockerhub_password }}"
+  when:
+  - dockerhub_username is defined
+  - dockerhub_username != ''
+  - dockerhub_password is defined
+  - dockerhub_password != ''
+  - oc_get_broker.stderr.find('NotFound') > -1
+
+- name: Ensure oc cluster is up
+  shell: oc cluster status
+  register: oc_cluster_status
+  changed_when: false
+  until: oc_cluster_status.rc == 0
+  poll: 5
+  retries: 30
+
+- name: Get oc cluster status
+  shell: oc cluster status
+  register: oc_cluster_status
+  changed_when: false
+
+- debug:
+    msg: "{{ oc_cluster_status.stdout_lines }}"

--- a/installer/roles/mobile-control-panel-setup/defaults/main.yml
+++ b/installer/roles/mobile-control-panel-setup/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# defaults file for mobile-control-panel-setup
+
+mcp_local_dir: "{{playbook_dir}}/.."

--- a/installer/roles/mobile-control-panel-setup/meta/main.yml
+++ b/installer/roles/mobile-control-panel-setup/meta/main.yml
@@ -1,0 +1,33 @@
+galaxy_info:
+  author: FeedHenry
+  description: Clone and install the Mobile Control Panel for Openshift
+
+  issue_tracker_url: https://github.com/feedhenry/mobile-control-panel/issues
+
+  license: license (MIT)
+
+  min_ansible_version: 2.2
+
+  platforms:
+  - name: macOS
+    versions:
+    - all
+  - name: OSX
+    versions:
+    - all
+  - name: Fedora
+    versions:
+    - 26
+    - 25
+
+  galaxy_tags:
+  - feedhenry
+  - openshift
+  - mobile
+  - control
+  - panel
+  - mcp
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/installer/roles/mobile-control-panel-setup/tasks/main.yml
+++ b/installer/roles/mobile-control-panel-setup/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+# tasks file for mobile-control-panel-setup
+
+- name: Execute MCP UI installer
+  shell: "{{ mcp_local_dir }}/ui/install.sh"
+  changed_when: false
+
+# TODO: Use Ansible module here, not oc from shell
+- name: Login as system:admin
+  shell: "oc login -u system:admin"
+  register: oc_login
+  changed_when: false
+  until: oc_login.rc == 0
+  poll: 5
+  retries: 30
+
+- name: Ensure unauthenticated access to the Mobile API Server
+  shell: oc adm policy add-cluster-role-to-group mobile-api-caller system:unauthenticated system:anonymous system:authenticated
+  changed_when: false
+
+- name: Ensure origin container is restarted
+  shell: docker restart origin
+  changed_when: false
+
+- name: Ensure origin container is running
+  shell: "docker inspect --format='{% raw %}{{.State.Status}}{% endraw %}' origin"
+  register: docker_inspect
+  changed_when: false
+  until: docker_inspect.stdout == 'running'
+  poll: 5
+  retries: 30
+
+- name: Ensure oc cluster is up
+  shell: oc cluster status
+  register: oc_cluster_status
+  changed_when: false
+  until: oc_cluster_status.rc == 0
+  poll: 5
+  retries: 30

--- a/installer/roles/oc-cluster-up/defaults/main.yml
+++ b/installer/roles/oc-cluster-up/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+# defaults file for oc-cluster-up
+
+service_catalog: "true"
+
+host_config_dir: "{{playbook_dir}}/../ui"
+
+cluster_version: v3.6.0-rc.0
+
+cluster_public_hostname: "192.168.37.1"

--- a/installer/roles/oc-cluster-up/meta/main.yml
+++ b/installer/roles/oc-cluster-up/meta/main.yml
@@ -1,0 +1,30 @@
+galaxy_info:
+  author: FeedHenry
+  description: Provision an OpenShift cluster using 'oc cluster up'
+
+  issue_tracker_url: https://github.com/feedhenry/mobile-control-panel/issues
+
+  license: license (MIT)
+
+  min_ansible_version: 2.2
+
+  platforms:
+  - name: macOS
+    versions:
+    - all
+  - name: OSX
+    versions:
+    - all
+  - name: Fedora
+    versions:
+    - 26
+    - 25
+
+  galaxy_tags:
+  - feedhenry
+  - openshift
+  - oc
+  - cluster
+  - up
+
+dependencies: []

--- a/installer/roles/oc-cluster-up/tasks/main.yml
+++ b/installer/roles/oc-cluster-up/tasks/main.yml
@@ -1,0 +1,77 @@
+---
+
+- name: Create alias for lo0
+  shell: ifconfig lo0 alias {{ cluster_public_hostname }}
+  become: yes
+  changed_when: false
+  when: ansible_os_family == "Darwin"
+
+- set_fact:
+    routing_suffix: "{{ cluster_public_hostname }}.nip.io"
+    public_hostname: "{{ cluster_public_hostname }}"
+  when: ansible_os_family == "Darwin"
+
+# TODO: This code path isn't tested yet
+- name: Get public IP for linux
+  shell: ip addr show docker0 | grep -Po 'inet \K[\d.]+'
+  register: docker0
+  when: ansible_os_family in ["RedHat", "Debian"]
+
+- set_fact:
+    routing_suffix: "{{ docker0.stdout }}"
+    public_hostname: "{{ docker0.stdout }}.nip.io"
+  when: ansible_os_family in ["RedHat", "Debian"]
+
+- name: Obtain status of oc cluster
+  shell: oc cluster status
+  register: oc_cluster_status
+  failed_when:
+  - oc_cluster_status.rc != 0
+  - oc_cluster_status.stdout.find('OpenShift cluster is not running') == -1
+  changed_when: false
+
+- block:
+  - set_fact:
+      cluster_up_command: oc cluster up
+
+  - set_fact:
+      cluster_up_command: "{{ cluster_up_command }} --service-catalog={{ service_catalog }}"
+    when:
+    - service_catalog is defined
+
+  - set_fact:
+      cluster_up_command: "{{ cluster_up_command }} --host-config-dir={{ host_config_dir }}"
+    when:
+    - host_config_dir is defined
+    - host_config_dir != ''
+
+  - set_fact:
+      cluster_up_command: "{{ cluster_up_command }} --use-existing-config={{ use_existing_config }}"
+    when:
+    - use_existing_config is defined
+
+  - set_fact:
+      cluster_up_command: "{{ cluster_up_command }} --routing-suffix={{ routing_suffix }}"
+    when:
+    - routing_suffix is defined
+    - routing_suffix != ''
+
+  - set_fact:
+      cluster_up_command: "{{ cluster_up_command }} --public-hostname={{ public_hostname }}"
+    when:
+    - public_hostname is defined
+    - public_hostname != ''
+
+  - set_fact:
+      cluster_up_command: "{{ cluster_up_command }} --version={{ cluster_version }}"
+    when:
+    - cluster_version is defined
+    - cluster_version != ''
+
+  - debug: msg="Executing oc cluster up command - {{ cluster_up_command }}"
+
+  - name: Cluster up
+    shell: "{{ cluster_up_command }}"
+    register: oc_cluster_up
+    changed_when: false
+  when: oc_cluster_status.stdout.find('OpenShift cluster is not running') > -1

--- a/installer/roles/template-service-broker-setup/defaults/main.yml
+++ b/installer/roles/template-service-broker-setup/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+# defaults file for template-service-broker-setup
+
+openshift_username: system:admin
+openshift_project: openshift
+
+templates:
+- https://raw.githubusercontent.com/feedhenry/fh-sync-server/master/fh-sync-server-DEVELOPMENT.yaml
+
+group: "system:openshift:templateservicebroker-client"
+roles:
+- "system:unauthenticated"
+- "system:authenticated"

--- a/installer/roles/template-service-broker-setup/meta/main.yml
+++ b/installer/roles/template-service-broker-setup/meta/main.yml
@@ -1,0 +1,30 @@
+galaxy_info:
+  author: FeedHenry
+  description: Setup Template Service Broker in OpenShift
+
+  issue_tracker_url: https://github.com/feedhenry/mobile-control-panel/issues
+
+  license: license (MIT)
+
+  min_ansible_version: 2.2
+
+  platforms:
+  - name: macOS
+    versions:
+    - all
+  - name: OSX
+    versions:
+    - all
+  - name: Fedora
+    versions:
+    - 26
+    - 25
+
+  galaxy_tags:
+  - feedhenry
+  - openshift
+  - template
+  - service
+  - broker
+
+dependencies: []

--- a/installer/roles/template-service-broker-setup/tasks/main.yml
+++ b/installer/roles/template-service-broker-setup/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+
+# TODO: Use Kubernetes Ansible modules here
+- name: Login to OpenShift
+  shell: oc login -u system:admin
+  changed_when: false
+
+- name: Create templates in required project
+  shell: oc create -f {{ item }} -n {{ openshift_project }}
+  register: oc_create
+  failed_when:
+  - oc_create.rc != 0
+  - oc_create.stderr.find('AlreadyExists') == -1
+  changed_when: oc_create.rc == 0
+  with_items: "{{ templates }}"
+
+- name: Add cluster roles to group
+  shell: oc adm policy add-cluster-role-to-group {{ group }} {{ roles | join(' ') }}
+  changed_when: false

--- a/installer/vars/mobile-control-panel.yml
+++ b/installer/vars/mobile-control-panel.yml
@@ -1,0 +1,3 @@
+---
+
+force_oc_link: yes

--- a/server/pkg/registry/mobileapp/strategy.go
+++ b/server/pkg/registry/mobileapp/strategy.go
@@ -63,7 +63,7 @@ func (apiServerStrategy) Validate(ctx genericapirequest.Context, obj runtime.Obj
 	}
 	ns := genericapirequest.NamespaceValue(ctx)
 	fmt.Println("strategy Validate", ns)
-	validAppTypes := map[string]bool{"android": true, "ios": true}
+	validAppTypes := map[string]bool{"android": true, "ios": true, "cordova": true}
 	if _, ok := validAppTypes[app.Spec.ClientType]; !ok {
 		errs = append(errs, field.Invalid(field.NewPath("Spec.ClientType"), app.Spec.ClientType, "invalid client type. valid types android or ios"))
 	}

--- a/ui/install.sh
+++ b/ui/install.sh
@@ -15,15 +15,6 @@ OPENSHIFT_CONFIG_DIR=$SCRIPT_ABSOLUTE_PATH
 OPENSHIFT_MASTER_CONFIG=$OPENSHIFT_CONFIG_DIR/master/master-config.yaml
 MCP_BASE_DIR=$OPENSHIFT_CONFIG_DIR
 
-# Start OpenShift with the current directory as the config dir
-# Using the current directory as the config dir is important for extension development
-# This allows changing of extension files and having them already mounted in the origin container
-oc cluster up --service-catalog --host-config-dir=${OPENSHIFT_CONFIG_DIR} --use-existing-config=true --version='v3.6.0-rc.0'
-
-# Grant unauthenticated access to the template service broker api
-oc login -u system:admin
-oc adm policy add-cluster-role-to-group system:openshift:templateservicebroker-client system:unauthenticated system:authenticated
-
 # Enable Extension Development
 sudo chmod 666 $OPENSHIFT_MASTER_CONFIG
 cd $SCRIPT_ABSOLUTE_PATH
@@ -37,12 +28,3 @@ oc patch scc/restricted -p '{"allowHostDirVolumePlugin":true}'
 # Install the Mobile API Server
 cd $MOBILE_API_SERVER_DIR
 $MOBILE_API_SERVER_INSTALL_SCRIPT
-
-# TODO: Wait for successful start of the Mobile API Server
-
-# Grant unauthenticated access to the Mobile API Server
-oc login -u system:admin
-oc adm policy add-cluster-role-to-group mobile-api-caller system:unauthenticated system:anonymous system:authenticated
-
-# Restart openshift to pick up master-config.yaml changes for extensions
-docker restart origin

--- a/ui/public/mcp.js
+++ b/ui/public/mcp.js
@@ -138,6 +138,10 @@ angular
               label: "iOS",
               iconClass: 'apple',
               clientType: 'ios'
+            }, {
+              label: "Cordova",
+              iconClass: 'Cordova',
+              clientType: 'Cordova'
             }];
 
           $scope.newMobileapp = {


### PR DESCRIPTION
This adds an installer directory to the project which contains an
Ansible installer. The installer will perform a number of tasks:

* Install the oc tool on the machine
* Invoke `oc cluster up` with the Service Catalog enabled
* Adding templates to the Template Service Broker in OpenShift
* Installing the MCP UI and server components/resources
* Creating an Ansible Service Broker in OpenShift

The installer depends on an external dependency, specified in
requirements.yml. This dependency installs the oc tool onto a
machine.