### PR TITLE
🎨 Add Mobile category to catalog UI

### DIFF
--- a/ui/public/mcp.js
+++ b/ui/public/mcp.js
@@ -1,5 +1,6 @@
 console.log('Mobile Control Panel Extension Loaded');
 
+// Add 'Mobile' to the left nav
 window.OPENSHIFT_CONSTANTS.PROJECT_NAVIGATION.splice(1, 0, {
   label: "Mobile",
   iconClass: "fa fa-mobile",
@@ -9,6 +10,14 @@ window.OPENSHIFT_CONSTANTS.PROJECT_NAVIGATION.splice(1, 0, {
     // TODO: Can this check if any mobile apps exist first?
     return true;
   }
+});
+
+// Add 'Mobile' category and sub-categories to the Service Catalog UI
+window.OPENSHIFT_CONSTANTS.SERVICE_CATALOG_CATEGORIES.splice(OPENSHIFT_CONSTANTS.SERVICE_CATALOG_CATEGORIES.length, 0, {
+  id: 'mobile', label: 'Mobile', subCategories: [
+    {id: 'apps', label: 'Apps', tags: ['mobile'], icon: 'fa fa-mobile'},
+    {id: 'services', label: 'Services', tags: ['mobile-service'], icon: 'fa fa-database'}
+  ]
 });
 
 angular


### PR DESCRIPTION
Add a 'Mobile' category to the end of the categories nav in the Service
Catalog UI.
Add 2 sub-categories:
* Apps - e.g. Android, iOS apps
* Services - e.g. fh-sync server, Push notifications

Currently, no services match the 2nd category, so it isn't visible. It is a placeholder

![image](https://user-images.githubusercontent.com/878251/29240145-f877c952-7f56-11e7-9bf9-f33cf650eb3c.png)
