### PR TITLE
🎨 Remove unused dependency from origin-web-console

### DIFF
--- a/ui/public/mcp.js
+++ b/ui/public/mcp.js
@@ -66,7 +66,6 @@ angular
                         $routeParams,
                         $scope,
                         $window,
-                        ApplicationGenerator,
                         AuthorizationService,
                         DataService,
                         Navigate,


### PR DESCRIPTION
The recommendation from @spadgett is to stick to services in
origin-web-common as they are less likely to change.
Using services from origin-web-console would have a higher chance
of breaking UI extensions in newer versions of openshift.

This change removes an unsued service that is *not* part of
origin-web-common. There is no risk from this change