### PR TITLE
Fix routing suffix when using linux

### DIFF
--- a/installer/roles/oc-cluster-up/tasks/main.yml
+++ b/installer/roles/oc-cluster-up/tasks/main.yml
@@ -18,8 +18,8 @@
   when: ansible_os_family in ["RedHat", "Debian"]
 
 - set_fact:
-    routing_suffix: "{{ docker0.stdout }}"
-    public_hostname: "{{ docker0.stdout }}.nip.io"
+    routing_suffix: "{{ docker0.stdout }}.nip.io"
+    public_hostname: "{{ docker0.stdout }}"
   when: ansible_os_family in ["RedHat", "Debian"]
 
 - name: Obtain status of oc cluster


### PR DESCRIPTION
Currently .nip.io is not being appended to the routing suffix option
during oc cluster up. This appends it.