### PR TITLE
Fix Ansible Service Broker install script

### DIFF
--- a/installer/roles/ansible-service-broker-setup/defaults/main.yml
+++ b/installer/roles/ansible-service-broker-setup/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
 # defaults file for ansible-service-broker-setup
-dockerhub_org: ansibleplaybookbundle
+dockerhub_org: feedhenry
 launch_apb_on_bind: false
+
+asb_template_commit: 4e98b3bd3e723a8db222ccaca4050a750cee1394
+asb_template_url: https://raw.githubusercontent.com/openshift/ansible-service-broker/{{ asb_template_commit }}/templates/deploy-ansible-service-broker.template.yaml

--- a/installer/roles/ansible-service-broker-setup/files/provision-ansible-service-broker.sh
+++ b/installer/roles/ansible-service-broker-setup/files/provision-ansible-service-broker.sh
@@ -4,7 +4,7 @@ readonly DOCKERHUB_USER="${1}"
 readonly DOCKERHUB_PASS="${2}"
 readonly DOCKERHUB_ORG="${3}"
 readonly LAUNCH_APB_ON_BIND="${4}"
-curl -s https://raw.githubusercontent.com/openshift/ansible-service-broker/master/templates/deploy-ansible-service-broker.template.yaml > /tmp/deploy-ansible-service-broker.template.yaml
+readonly ROUTING_SUFFIX="${5}"
 
 oc login -u system:admin
 oc new-project ansible-service-broker
@@ -13,26 +13,5 @@ oc process -f /tmp/deploy-ansible-service-broker.template.yaml \
     -p DOCKERHUB_USER="${DOCKERHUB_USER}" \
     -p DOCKERHUB_PASS="${DOCKERHUB_PASS}" \
     -p DOCKERHUB_ORG="${DOCKERHUB_ORG}" \
-    -p LAUNCH_APB_ON_BIND="${LAUNCH_APB_ON_BIND}" | oc create -f -
-
-if [ "${?}" -ne 0 ]; then
-	echo "Error processing template and creating deployment"
-	exit
-fi
-
-ASB_ROUTE=`oc get routes | grep ansible-service-broker | awk '{print $2}'`
-
-cat <<EOF > /tmp/ansible-service-broker.broker
-    apiVersion: servicecatalog.k8s.io/v1alpha1
-    kind: Broker
-    metadata:
-      name: ansible-service-broker
-    spec:
-      url: https://${ASB_ROUTE}
-      authInfo:
-        basicAuthSecret:
-          namespace: ansible-service-broker
-          name: asb-auth-secret
-EOF
-
-oc create -f /tmp/ansible-service-broker.broker
+    -p LAUNCH_APB_ON_BIND="${LAUNCH_APB_ON_BIND}" \
+    -p ROUTING_SUFFIX="${ROUTING_SUFFIX}" | oc create -f -

--- a/installer/roles/ansible-service-broker-setup/tasks/main.yml
+++ b/installer/roles/ansible-service-broker-setup/tasks/main.yml
@@ -20,8 +20,13 @@
       dest: /tmp/provision-ansible-service-broker.sh
       mode: u+x
 
+  - name: Retrieve Ansible Service Broker template
+    get_url:
+      url: "{{ asb_template_url }}"
+      dest: /tmp/deploy-ansible-service-broker.template.yaml
+
   - name: Execute Ansible Service Broker provision script
-    shell: bash /tmp/provision-ansible-service-broker.sh "{{ dockerhub_username }}" "{{ dockerhub_password }}" "{{ dockerhub_org }}" "{{ launch_apb_on_bind }}"
+    shell: bash /tmp/provision-ansible-service-broker.sh "{{ dockerhub_username }}" "{{ dockerhub_password }}" "{{ dockerhub_org }}" "{{ launch_apb_on_bind }}" "{{ cluster_public_hostname }}.nip.io"
   when:
   - dockerhub_username is defined
   - dockerhub_username != ''


### PR DESCRIPTION
A backwards incompatible change was made to the Ansible install
script that is used to set up the Ansible Service Broker.

This fixes the issues that were caused by the script change.